### PR TITLE
update require statement to new easy form

### DIFF
--- a/brainfuck.scm
+++ b/brainfuck.scm
@@ -1,7 +1,7 @@
-(require lib.easy
-	 lib.cj-source
-	 lib.cj-source-quasiquote
-	 lib.cj-setf)
+(require easy
+         cj-source
+         cj-source-quasiquote
+         cj-setf)
 
 
 ;; https://en.wikipedia.org/wiki/Brainfuck


### PR DESCRIPTION
Hi Christian,

Hope all is well! 

I was trying to run your brainfuck interpreter and I noticed that the require form is not up to date with the latest easy require api.

I'm just opening this pull request as a reminder to update the require form to the latest syntax.

I thought it would be easier to show this with a diff/commit. 

You don't need to merge my commit for this if you prefer to just add it yourself. This is just a reminder.